### PR TITLE
Fix for export race condition and RPi2 setDirection bug.

### DIFF
--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -54,6 +54,17 @@ var _export = function(n, fn) {
 		}, 1);
 	}
 };
+var _testwrite = function(file, fn) {
+	fs.open(file, function(err, fd) {
+		if (err) {
+			fn(false, err);
+			return;
+		}
+		fs.close(fd, function(err){
+			fn(true, null);	
+		});
+	});
+};
 
 // fs.watch doesn't get fired because the file never
 // gets 'accessed' when setting header via hardware
@@ -98,9 +109,29 @@ var GPIO = function(headerNum, opts) {
 	this.PATH.DIRECTION = this.PATH.PIN + 'direction';
 
 	this.export(function() {
-		self.setDirection(dir, function () {
-			if(typeof opts.ready === 'function') opts.ready.call(self);
-		});
+		var onSuccess = function() {
+			self.setDirection(dir, function () {
+				if(typeof opts.ready === 'function') opts.ready.call(self);
+			});
+		};
+		var attempts = 0;
+		var makeAttempt = function() {
+			attempts += 1;
+			_testwrite(this.PATH.DIRECTION, function(success, err){
+				if (success) {
+					onSuccess();
+				} else {
+					logMessage('Could not write to pin: ' + err.code);
+					if (attempts <= 5) {
+						logMessage('Trying again in 100ms');
+						setTimeout(makeAttempt, 100);
+					} else {
+						logMessage('Failed to access pin after 5 attempts. Giving up.');
+					}
+				}
+			});
+		};
+		makeAttempt();
 	});
 };
 
@@ -148,18 +179,22 @@ GPIO.prototype.setDirection = function(dir, fn) {
 		}
 	}
 	_read(path, function(currDir) {
+		var changedDirection = false;
 		if(currDir.indexOf(dir) !== -1) {
 			logMessage('Current direction is already ' + dir);
-			watch();
-			if(typeof fn === 'function') fn();
+			logMessage('Attempting to set direction anyway.');
 		} else {
-			_write(dir, path, function() {
-				watch();
-
-				if(typeof fn === 'function') fn();
-				self.emit('directionChange', dir);
-			}, 1);
+			changedDirection = true;
 		}
+		_write(dir, path, function() {
+			watch();
+
+			if(typeof fn === 'function') fn();
+			if (changedDirection) {
+				self.emit('directionChange', dir);
+			}
+		}, 1);
+	
 	});
 };
 

--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -55,7 +55,7 @@ var _export = function(n, fn) {
 	}
 };
 var _testwrite = function(file, fn) {
-	fs.open(file, function(err, fd) {
+	fs.open(file, 'w', function(err, fd) {
 		if (err) {
 			fn(false, err);
 			return;
@@ -117,7 +117,7 @@ var GPIO = function(headerNum, opts) {
 		var attempts = 0;
 		var makeAttempt = function() {
 			attempts += 1;
-			_testwrite(this.PATH.DIRECTION, function(success, err){
+			_testwrite(self.PATH.DIRECTION, function(success, err){
 				if (success) {
 					onSuccess();
 				} else {


### PR DESCRIPTION
Fix for export race condition:
udev rules are often used to set group ownership (gpio group) and file permissions (group rw) as gpio devices are exported and become available in /sys/glass/gpio/gpio*. This activity can take an indeterminate amount of time, and the "ready" callback often was called before file permissions were set, causing EACCESS errors. This change will poll the direction pin for up to half a second to wait for write access before "ready" is called.

setDirection bug:
On RPi2, we've encountered a new bug where a pin's direction might return "in" or "out," but it is unusable until the direction is explicitly set. This change forces setDirection to write to the direction file, even if it already appears to be set to the same value.