### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I haven't maintained this project for a while now, and it's unlikely I will prov
 
 ---
 
-##Installation
+## Installation
 ##### Get node.js on your Raspberry Pi
 On Raspbian, you can simply run `apt-get install nodejs`,
 otherwise, [compile it](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
