### PR TITLE
Update value before ready callback on input

### DIFF
--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -111,7 +111,15 @@ var GPIO = function(headerNum, opts) {
 	this.export(function() {
 		var onSuccess = function() {
 			self.setDirection(dir, function () {
-				if(typeof opts.ready === 'function') opts.ready.call(self);
+				if ( dir === "out") {
+					if(typeof opts.ready === 'function') opts.ready.call(self);
+				} else {
+					self.value = undefined;
+					self._get(function(val) {
+						self.value = val;
+						if (typeof opts.ready === 'function') opts.ready.call(self);
+					});
+				}
 			});
 		};
 		var attempts = 0;


### PR DESCRIPTION
This fix a bug that before first change,
value is always zero, while it could be different.

For instance using Anavi's Flex RPi hat
button is high by default (when not pressed).

Note if you need to test this device,
make sure to configure pullup before:
    gpio -g mode 11 up

Bug: https://github.com/EnotionZ/GpiO/issues/35
Change-Id: Ib61747dd145c98f19e2789092a471fab2816eeed
Signed-off-by: Philippe Coval <p.coval@samsung.com>