### PR TITLE
gpio: Support boolean as set value

### DIFF
--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -221,7 +221,8 @@ GPIO.prototype._get = function(fn) {
 GPIO.prototype.set = function(v, fn) {
 	var self = this;
 	var callback = typeof v === 'function' ? v : fn;
-	if(typeof v !== "number" || v !== 0) v = 1;
+	if (typeof v === "boolean" || ) v = v ? 1 : 0;
+	if (typeof v !== "number" || v !== 0) v = 1;
 
 	// if direction is out, just emit change event since we can reliably predict
 	// if the value has changed; we don't have to rely on watching a file


### PR DESCRIPTION
More refactoring can be done later, to only use booleans

Change-Id: Iedaa4ddb5fbaff9e210183ee2aeea2568fe5cf7d
Signed-off-by: Philippe Coval <p.coval@samsung.com>