### PR TITLE
export: Use undeprecated fs.existsSync

### DIFF
--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var util = require('util');
 var path = require('path');
 var EventEmitter = require('events').EventEmitter;
-var exists = fs.exists || path.exists;
+var exists = fs.existsSync || path.exists;
 
 var gpiopath = '/sys/class/gpio/';
 


### PR DESCRIPTION
fs.exists expects a callback so it won't work correctly anyway

path.exists might be removed in later change too

Change-Id: If6a07a0148df78525a7689cc557c556f10b039e6
Signed-off-by: Philippe Coval <p.coval@samsung.com>