### PR TITLE
Fixed data argument related issue found on node v16.14.2

### DIFF
--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -231,8 +231,8 @@ GPIO.prototype._get = function(fn) {
 GPIO.prototype.set = function(v, fn) {
 	var self = this;
 	var callback = typeof v === 'function' ? v : fn;
-	if (typeof v === "boolean") v = v ? 1 : 0;
-	if (typeof v !== "number" || v !== 0) v = 1;
+	if (typeof v === "boolean") v = v ? "1" : "0";
+	if (typeof v === "number") v = parseInt(v).toString();
 
 	// if direction is out, just emit change event since we can reliably predict
 	// if the value has changed; we don't have to rely on watching a file
@@ -249,7 +249,7 @@ GPIO.prototype.set = function(v, fn) {
 		}
 	}
 };
-GPIO.prototype.reset = function(fn) { this.set(0, fn); };
+GPIO.prototype.reset = function(fn) { this.set("0", fn); };
 
 exports.logging = false;
 exports.export = function(headerNum, opts) { return new GPIO(headerNum, opts); };


### PR DESCRIPTION
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (1)

Error stack

2024-02-13 19:56 +00:00:     at _write (/TestApp/node_modules/gpio/lib/gpio.js:18:5)
2024-02-13 19:56 +00:00:     at GPIO.set (/TestApp/node_modules/gpio/lib/gpio.js:245:4)
2024-02-13 19:56 +00:00:     at Timeout._onTimeout (/TestApp/sensors/light.js:261:40)
